### PR TITLE
Add python 3.13 and remove 3.8

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,11 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         PYTHON:
-          - 3.8.20
           - 3.9.20
           - 3.10.15
           - 3.11.10
           - 3.12.7
+          - 3.13.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ TAG = latest
 JENKINS_AGENT = 3283.v92c105e0f819-1-jdk17
 
 # Python versions: $PYTHON_MAJOR.$PYTHON_PATCH
-PYTHON_MAJOR = 3.12
-PYTHON_PATCH = 7
+PYTHON_MAJOR = 3.13
+PYTHON_PATCH = 0
 
 pull:
 	docker pull $(shell grep FROM Dockerfile | sed 's/^FROM//g' | sed "s/\$${JENKINS_AGENT}/$(JENKINS_AGENT)/g";)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jenkins Agent and python
 
 [![GitHub release](https://img.shields.io/github/release/flaconi/docker-jnlp-slave-py.svg?label=changelog)](https://github.com/flaconi/docker-jnlp-slave-py/releases/latest)
-[![Docker Pulls](https://img.shields.io/docker/pulls/flaconi/jnlp-slave-py.svg)](https://hub.docker.com/r/flaconi/jnlp-slave-py/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/flaconi/jnlp-slave-py)](https://hub.docker.com/r/flaconi/jnlp-slave-py/)
 
 A Jenkins agent which can connect to Jenkins using JNLP4 + python preinstalled


### PR DESCRIPTION
- A new version `python 3.13.0` is released
- `python 3.8` has reached end-of-life on **2024-10-07**